### PR TITLE
Add localStorage persistence to app pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Development
+
+Install dependencies before running lint or other npm scripts:
+
+```bash
+pnpm install
+npm run lint
+```

--- a/app/aprendizaje/page.tsx
+++ b/app/aprendizaje/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -144,24 +144,30 @@ export default function AprendizajePage() {
 
   // Cargar datos almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("aprendizaje-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("aprendizaje-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
         if (parsed.books) setBooks(parsed.books)
         if (parsed.readingGoals) setReadingGoals(parsed.readingGoals)
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading aprendizaje-data", err)
     }
   }, [])
 
   // Guardar datos
   useEffect(() => {
-    localStorage.setItem(
-      "aprendizaje-data",
-      JSON.stringify({ books, readingGoals })
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "aprendizaje-data",
+        JSON.stringify({ books, readingGoals })
+      )
+    } catch (err) {
+      console.error("Error saving aprendizaje-data", err)
+    }
   }, [books, readingGoals])
 
   // Calcular estadísticas

--- a/app/aprendizaje/page.tsx
+++ b/app/aprendizaje/page.tsx
@@ -142,6 +142,28 @@ export default function AprendizajePage() {
     notes: "",
   })
 
+  // Cargar datos almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("aprendizaje-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        if (parsed.books) setBooks(parsed.books)
+        if (parsed.readingGoals) setReadingGoals(parsed.readingGoals)
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar datos
+  useEffect(() => {
+    localStorage.setItem(
+      "aprendizaje-data",
+      JSON.stringify({ books, readingGoals })
+    )
+  }, [books, readingGoals])
+
   // Calcular estadísticas
   const totalBooksRead = books.filter((book) => book.status === "completed").length
   const currentlyReading = books.filter((book) => book.status === "reading").length

--- a/app/coach-ia/page.tsx
+++ b/app/coach-ia/page.tsx
@@ -85,23 +85,29 @@ export default function CoachIAPage() {
 
   // Cargar mensajes almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("coach-ia-messages")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("coach-ia-messages")
+      if (stored) {
         const parsed = JSON.parse(stored)
-        setMessages(parsed.map((m) => ({ ...m, timestamp: new Date(m.timestamp) })))
-      } catch {
-        // ignore parse errors
+        setMessages(parsed.map((m: any) => ({ ...m, timestamp: new Date(m.timestamp) })))
       }
+    } catch (err) {
+      console.error("Error loading coach-ia-messages", err)
     }
   }, [])
 
   // Guardar mensajes
   useEffect(() => {
-    localStorage.setItem(
-      "coach-ia-messages",
-      JSON.stringify(messages.map((m) => ({ ...m, timestamp: m.timestamp })))
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "coach-ia-messages",
+        JSON.stringify(messages.map((m) => ({ ...m, timestamp: m.timestamp })))
+      )
+    } catch (err) {
+      console.error("Error saving coach-ia-messages", err)
+    }
   }, [messages])
 
   const scrollToBottom = () => {

--- a/app/coach-ia/page.tsx
+++ b/app/coach-ia/page.tsx
@@ -83,6 +83,27 @@ export default function CoachIAPage() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
+  // Cargar mensajes almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("coach-ia-messages")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        setMessages(parsed.map((m) => ({ ...m, timestamp: new Date(m.timestamp) })))
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar mensajes
+  useEffect(() => {
+    localStorage.setItem(
+      "coach-ia-messages",
+      JSON.stringify(messages.map((m) => ({ ...m, timestamp: m.timestamp })))
+    )
+  }, [messages])
+
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
   }

--- a/app/diario/page.tsx
+++ b/app/diario/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -127,20 +127,26 @@ export default function DiarioPage() {
 
   // Cargar entradas almacenadas
   useEffect(() => {
-    const stored = localStorage.getItem("diario-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("diario-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
         if (parsed.entries) setEntries(parsed.entries)
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading diario-data", err)
     }
   }, [])
 
   // Guardar entradas
   useEffect(() => {
-    localStorage.setItem("diario-data", JSON.stringify({ entries }))
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem("diario-data", JSON.stringify({ entries }))
+    } catch (err) {
+      console.error("Error saving diario-data", err)
+    }
   }, [entries])
 
   const editorRef = useRef<HTMLDivElement>(null)

--- a/app/diario/page.tsx
+++ b/app/diario/page.tsx
@@ -125,6 +125,24 @@ export default function DiarioPage() {
   const [newTag, setNewTag] = useState("")
   const [fontSize, setFontSize] = useState("16")
 
+  // Cargar entradas almacenadas
+  useEffect(() => {
+    const stored = localStorage.getItem("diario-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        if (parsed.entries) setEntries(parsed.entries)
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar entradas
+  useEffect(() => {
+    localStorage.setItem("diario-data", JSON.stringify({ entries }))
+  }, [entries])
+
   const editorRef = useRef<HTMLDivElement>(null)
 
   // Obtener todas las etiquetas únicas

--- a/app/entrenamiento/page.tsx
+++ b/app/entrenamiento/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -113,22 +113,28 @@ export default function EntrenamientoPage() {
 
   // Cargar entrenamientos almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("entrenamiento-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("entrenamiento-data")
+      if (stored) {
         setTodayWorkouts(JSON.parse(stored))
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading entrenamiento-data", err)
     }
   }, [])
 
   // Guardar entrenamientos
   useEffect(() => {
-    localStorage.setItem(
-      "entrenamiento-data",
-      JSON.stringify(todayWorkouts)
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "entrenamiento-data",
+        JSON.stringify(todayWorkouts)
+      )
+    } catch (err) {
+      console.error("Error saving entrenamiento-data", err)
+    }
   }, [todayWorkouts])
 
   // Próximos entrenamientos

--- a/app/entrenamiento/page.tsx
+++ b/app/entrenamiento/page.tsx
@@ -111,6 +111,26 @@ export default function EntrenamientoPage() {
     },
   ])
 
+  // Cargar entrenamientos almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("entrenamiento-data")
+    if (stored) {
+      try {
+        setTodayWorkouts(JSON.parse(stored))
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar entrenamientos
+  useEffect(() => {
+    localStorage.setItem(
+      "entrenamiento-data",
+      JSON.stringify(todayWorkouts)
+    )
+  }, [todayWorkouts])
+
   // Próximos entrenamientos
   const upcomingWorkouts = [
     {

--- a/app/finanzas/page.tsx
+++ b/app/finanzas/page.tsx
@@ -230,6 +230,36 @@ const FinanzasPage = () => {
     deadline: "",
   })
 
+  // Cargar datos almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("finanzas-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        if (parsed.expenseData) setExpenseData(parsed.expenseData)
+        if (parsed.transactions)
+          setTransactions(
+            parsed.transactions.map((t) => ({ ...t, date: new Date(t.date) }))
+          )
+        if (parsed.financialGoals) setFinancialGoals(parsed.financialGoals)
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar actualizaciones
+  useEffect(() => {
+    localStorage.setItem(
+      "finanzas-data",
+      JSON.stringify({
+        expenseData,
+        transactions: transactions.map((t) => ({ ...t, date: t.date })),
+        financialGoals,
+      })
+    )
+  }, [expenseData, transactions, financialGoals])
+
   // Filtrar transacciones
   const filteredTransactions = transactions.filter((transaction) => {
     if (transactionFilters.type !== "todos" && transaction.type !== transactionFilters.type) return false

--- a/app/finanzas/page.tsx
+++ b/app/finanzas/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -232,32 +232,38 @@ const FinanzasPage = () => {
 
   // Cargar datos almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("finanzas-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("finanzas-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
         if (parsed.expenseData) setExpenseData(parsed.expenseData)
         if (parsed.transactions)
           setTransactions(
-            parsed.transactions.map((t) => ({ ...t, date: new Date(t.date) }))
+            parsed.transactions.map((t: any) => ({ ...t, date: new Date(t.date) }))
           )
         if (parsed.financialGoals) setFinancialGoals(parsed.financialGoals)
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading finanzas-data", err)
     }
   }, [])
 
   // Guardar actualizaciones
   useEffect(() => {
-    localStorage.setItem(
-      "finanzas-data",
-      JSON.stringify({
-        expenseData,
-        transactions: transactions.map((t) => ({ ...t, date: t.date })),
-        financialGoals,
-      })
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "finanzas-data",
+        JSON.stringify({
+          expenseData,
+          transactions: transactions.map((t) => ({ ...t, date: t.date })),
+          financialGoals,
+        })
+      )
+    } catch (err) {
+      console.error("Error saving finanzas-data", err)
+    }
   }, [expenseData, transactions, financialGoals])
 
   // Filtrar transacciones

--- a/app/habitos/page.tsx
+++ b/app/habitos/page.tsx
@@ -138,6 +138,34 @@ export default function HabitosPage() {
     icon: "⭐",
   })
 
+  // Cargar hábitos almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("habitos-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        setHabits(
+          parsed.map((h) => ({
+            ...h,
+            lastCompleted: h.lastCompleted ? new Date(h.lastCompleted) : undefined,
+          }))
+        )
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar hábitos
+  useEffect(() => {
+    localStorage.setItem(
+      "habitos-data",
+      JSON.stringify(
+        habits.map((h) => ({ ...h, lastCompleted: h.lastCompleted }))
+      )
+    )
+  }, [habits])
+
   // Función para reiniciar hábitos a las 00:00
   useEffect(() => {
     const checkMidnight = () => {

--- a/app/habitos/page.tsx
+++ b/app/habitos/page.tsx
@@ -140,36 +140,43 @@ export default function HabitosPage() {
 
   // Cargar hábitos almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("habitos-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("habitos-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
         setHabits(
-          parsed.map((h) => ({
+          parsed.map((h: any) => ({
             ...h,
             lastCompleted: h.lastCompleted ? new Date(h.lastCompleted) : undefined,
           }))
         )
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading habitos-data", err)
     }
   }, [])
 
   // Guardar hábitos
   useEffect(() => {
-    localStorage.setItem(
-      "habitos-data",
-      JSON.stringify(
-        habits.map((h) => ({ ...h, lastCompleted: h.lastCompleted }))
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "habitos-data",
+        JSON.stringify(
+          habits.map((h) => ({ ...h, lastCompleted: h.lastCompleted }))
+        )
       )
-    )
+    } catch (err) {
+      console.error("Error saving habitos-data", err)
+    }
   }, [habits])
 
   // Función para reiniciar hábitos a las 00:00
   useEffect(() => {
     const checkMidnight = () => {
       const now = new Date()
+      if (typeof window === "undefined") return
       const lastReset = localStorage.getItem("lastHabitReset")
       const today = now.toDateString()
 
@@ -181,7 +188,11 @@ export default function HabitosPage() {
             completed: false,
           })),
         )
-        localStorage.setItem("lastHabitReset", today)
+        try {
+          localStorage.setItem("lastHabitReset", today)
+        } catch (err) {
+          console.error("Error saving lastHabitReset", err)
+        }
       }
     }
 

--- a/app/mentalidad/page.tsx
+++ b/app/mentalidad/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -157,30 +157,36 @@ export default function MentalidadPage() {
 
   // Cargar datos almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("mentalidad-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("mentalidad-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
         if (parsed.mentalGoals) setMentalGoals(parsed.mentalGoals)
         if (parsed.reflections)
           setReflections(
-            parsed.reflections.map((r) => ({ ...r, date: new Date(r.date) }))
+            parsed.reflections.map((r: any) => ({ ...r, date: new Date(r.date) }))
           )
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading mentalidad-data", err)
     }
   }, [])
 
   // Guardar datos
   useEffect(() => {
-    localStorage.setItem(
-      "mentalidad-data",
-      JSON.stringify({
-        mentalGoals,
-        reflections: reflections.map((r) => ({ ...r, date: r.date })),
-      })
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "mentalidad-data",
+        JSON.stringify({
+          mentalGoals,
+          reflections: reflections.map((r) => ({ ...r, date: r.date })),
+        })
+      )
+    } catch (err) {
+      console.error("Error saving mentalidad-data", err)
+    }
   }, [mentalGoals, reflections])
 
   const toggleGoalCompletion = (goalId: string) => {

--- a/app/mentalidad/page.tsx
+++ b/app/mentalidad/page.tsx
@@ -155,6 +155,34 @@ export default function MentalidadPage() {
     tomorrow: "",
   })
 
+  // Cargar datos almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("mentalidad-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        if (parsed.mentalGoals) setMentalGoals(parsed.mentalGoals)
+        if (parsed.reflections)
+          setReflections(
+            parsed.reflections.map((r) => ({ ...r, date: new Date(r.date) }))
+          )
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar datos
+  useEffect(() => {
+    localStorage.setItem(
+      "mentalidad-data",
+      JSON.stringify({
+        mentalGoals,
+        reflections: reflections.map((r) => ({ ...r, date: r.date })),
+      })
+    )
+  }, [mentalGoals, reflections])
+
   const toggleGoalCompletion = (goalId: string) => {
     setMentalGoals((prevGoals) =>
       prevGoals.map((goal) =>

--- a/app/nutricion/page.tsx
+++ b/app/nutricion/page.tsx
@@ -126,6 +126,29 @@ export default function NutricionPage() {
   const [editingMeal, setEditingMeal] = useState(null)
   const [editingFoods, setEditingFoods] = useState([])
 
+  // Cargar datos almacenados
+  useEffect(() => {
+    const stored = localStorage.getItem("nutricion-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        if (parsed.userProfile) setUserProfile(parsed.userProfile)
+        if (parsed.meals) setMeals(parsed.meals)
+        if (parsed.lastResetDate) setLastResetDate(parsed.lastResetDate)
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar datos
+  useEffect(() => {
+    localStorage.setItem(
+      "nutricion-data",
+      JSON.stringify({ userProfile, meals, lastResetDate })
+    )
+  }, [userProfile, meals, lastResetDate])
+
   // Verificar si necesita reset a medianoche
   useEffect(() => {
     const checkMidnightReset = () => {

--- a/app/nutricion/page.tsx
+++ b/app/nutricion/page.tsx
@@ -128,30 +128,37 @@ export default function NutricionPage() {
 
   // Cargar datos almacenados
   useEffect(() => {
-    const stored = localStorage.getItem("nutricion-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("nutricion-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
         if (parsed.userProfile) setUserProfile(parsed.userProfile)
         if (parsed.meals) setMeals(parsed.meals)
         if (parsed.lastResetDate) setLastResetDate(parsed.lastResetDate)
-      } catch {
-        // ignore parse errors
       }
+    } catch (err) {
+      console.error("Error loading nutricion-data", err)
     }
   }, [])
 
   // Guardar datos
   useEffect(() => {
-    localStorage.setItem(
-      "nutricion-data",
-      JSON.stringify({ userProfile, meals, lastResetDate })
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "nutricion-data",
+        JSON.stringify({ userProfile, meals, lastResetDate })
+      )
+    } catch (err) {
+      console.error("Error saving nutricion-data", err)
+    }
   }, [userProfile, meals, lastResetDate])
 
   // Verificar si necesita reset a medianoche
   useEffect(() => {
     const checkMidnightReset = () => {
+      if (typeof window === "undefined") return
       const currentDate = new Date().toDateString()
       if (currentDate !== lastResetDate) {
         // Reset de comidas a medianoche

--- a/app/tareas/page.tsx
+++ b/app/tareas/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -111,23 +111,29 @@ export default function TareasPage() {
 
   // Cargar tareas almacenadas
   useEffect(() => {
-    const stored = localStorage.getItem("tasks-data")
-    if (stored) {
-      try {
+    if (typeof window === "undefined") return
+    try {
+      const stored = localStorage.getItem("tasks-data")
+      if (stored) {
         const parsed = JSON.parse(stored)
-        setTasks(parsed.map((t) => ({ ...t, createdAt: new Date(t.createdAt) })))
-      } catch {
-        // ignore parse errors
+        setTasks(parsed.map((t: any) => ({ ...t, createdAt: new Date(t.createdAt) })))
       }
+    } catch (err) {
+      console.error("Error loading tasks-data", err)
     }
   }, [])
 
   // Guardar tareas
   useEffect(() => {
-    localStorage.setItem(
-      "tasks-data",
-      JSON.stringify(tasks.map((t) => ({ ...t, createdAt: t.createdAt })))
-    )
+    if (typeof window === "undefined") return
+    try {
+      localStorage.setItem(
+        "tasks-data",
+        JSON.stringify(tasks.map((t) => ({ ...t, createdAt: t.createdAt })))
+      )
+    } catch (err) {
+      console.error("Error saving tasks-data", err)
+    }
   }, [tasks])
 
   // Estadísticas

--- a/app/tareas/page.tsx
+++ b/app/tareas/page.tsx
@@ -109,6 +109,27 @@ export default function TareasPage() {
     category: "",
   })
 
+  // Cargar tareas almacenadas
+  useEffect(() => {
+    const stored = localStorage.getItem("tasks-data")
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        setTasks(parsed.map((t) => ({ ...t, createdAt: new Date(t.createdAt) })))
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  // Guardar tareas
+  useEffect(() => {
+    localStorage.setItem(
+      "tasks-data",
+      JSON.stringify(tasks.map((t) => ({ ...t, createdAt: t.createdAt })))
+    )
+  }, [tasks])
+
   // Estadísticas
   const totalTasks = tasks.length
   const completedTasks = tasks.filter((task) => task.completed).length

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "eslint": "^8",
+    "eslint-config-next": "^15",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- persist finance data on the Finanzas page
- persist tasks on the Tareas page
- persist learning data on the Aprendizaje page
- persist workouts on the Entrenamiento page
- persist habits on the Hábitos page
- persist nutrition profile and meals
- persist diary entries
- persist mental goals and reflections
- persist AI chat messages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686adc989850832ea46874d35c221634